### PR TITLE
reproducible builds

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,6 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       new_version: ${{ steps.output.outputs.new_version }}
+      build_timestamp: ${{ steps.output.outputs.build_timestamp }}
     steps:
     - uses: actions/checkout@v4.1.7
     - name: Bump version and push tag
@@ -55,6 +56,7 @@ jobs:
         NEW_VERSION: ${{ steps.tag.outputs.new_version }}
       run: |
         echo "new_version=${NEW_VERSION:-$GITHUB_SHA}" >> $GITHUB_OUTPUT
+        echo "build_timestamp=$(date --iso-8601=seconds)" >> $GITHUB_OUTPUT
     - name: Make sure build did not change anything
       run: git diff --exit-code
   macos:
@@ -62,6 +64,7 @@ jobs:
     needs: version
     env:
       REVISION: ${{ needs.version.outputs.new_version }}
+      BUILD_TIMESTAMP: ${{ needs.version.outputs.build_timestamp }}
     steps:
     - uses: actions/checkout@v4.1.7
     - uses: graalvm/setup-graalvm@v1.2.3
@@ -95,6 +98,7 @@ jobs:
     needs: version
     env:
       REVISION: ${{ needs.version.outputs.new_version }}
+      BUILD_TIMESTAMP: ${{ needs.version.outputs.build_timestamp }}
     steps:
     - uses: actions/checkout@v4.1.7
     - uses: graalvm/setup-graalvm@v1.2.3
@@ -128,6 +132,7 @@ jobs:
     needs: version
     env:
       REVISION: ${{ needs.version.outputs.new_version }}
+      BUILD_TIMESTAMP: ${{ needs.version.outputs.build_timestamp }}
     steps:
     - uses: actions/checkout@v4.1.7
     - uses: graalvm/setup-graalvm@v1.2.3
@@ -245,6 +250,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         REVISION: ${{ needs.version.outputs.new_version }}
+        BUILD_TIMESTAMP: ${{ needs.version.outputs.build_timestamp }}
       run: |
         ./mvnw \
           --batch-mode \

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,17 @@
 				</plugins>
 			</build>
 		</profile>
+		<profile>
+			<id>env-build-timestamp</id>
+			<activation>
+				<property>
+					<name>env.BUILD_TIMESTAMP</name>
+				</property>
+			</activation>
+			<properties>
+				<project.build.outputTimestamp>${env.BUILD_TIMESTAMP}</project.build.outputTimestamp>
+			</properties>
+		</profile>
 	</profiles>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 		<platform>unknown</platform>
 		<start-class>io.github.arlol.chorito.Main</start-class>
 		<ec4j.version>2.2.2</ec4j.version>
+		<project.build.outputTimestamp>2023-01-01T00:00:00Z</project.build.outputTimestamp>
 	</properties>
 
 	<profiles>
@@ -250,6 +251,24 @@
 						<goals>
 							<goal>flatten</goal>
 						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>versions-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>versions-set</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>set-property</goal>
+						</goals>
+						<configuration>
+							<generateBackupPoms>false</generateBackupPoms>
+							<newVersion>${project.build.outputTimestamp}</newVersion>
+							<property>project.build.outputTimestamp</property>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/src/test/resources/io/github/arlol/chorito/github-actions/upx-removal-output.yaml
+++ b/src/test/resources/io/github/arlol/chorito/github-actions/upx-removal-output.yaml
@@ -65,6 +65,7 @@ jobs:
     needs: version
     env:
       REVISION: ${{ needs.version.outputs.new_version }}
+      BUILD_TIMESTAMP: ${{ needs.version.outputs.build_timestamp }}
     steps:
     - uses: actions/checkout@v4.1.1
     - uses: graalvm/setup-graalvm@v1.1.5
@@ -98,6 +99,7 @@ jobs:
     needs: version
     env:
       REVISION: ${{ needs.version.outputs.new_version }}
+      BUILD_TIMESTAMP: ${{ needs.version.outputs.build_timestamp }}
     steps:
     - uses: actions/checkout@v4.1.1
     - uses: graalvm/setup-graalvm@v1.1.5
@@ -131,6 +133,7 @@ jobs:
     needs: version
     env:
       REVISION: ${{ needs.version.outputs.new_version }}
+      BUILD_TIMESTAMP: ${{ needs.version.outputs.build_timestamp }}
     steps:
     - uses: actions/checkout@v4.1.1
     - uses: graalvm/setup-graalvm@v1.1.5


### PR DESCRIPTION
So the build timestamp should be part of the released pom.
versions:set would work - but it changes the pom - which I dont want; the build should be clean
flatten is used as part of the build already: does it make sense to add that functionality there? would it even work?