### PR TITLE
Add dependency labels to Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,13 @@
   "extends": [
     "config:recommended"
   ],
+  "labels": ["dependencies"],
+  "addLabels": ["{{manager}}"],
   "minimumReleaseAge": "7 days",
   "schedule": ["on the 20th day of the month"],
   "vulnerabilityAlerts": {
     "schedule": ["at any time"],
-    "minimumReleaseAge": "0 days"
+    "minimumReleaseAge": "0 days",
+    "addLabels": ["security"]
   }
 }

--- a/src/main/java/io/github/arlol/chorito/chores/RenovateChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/RenovateChore.java
@@ -1,6 +1,7 @@
 package io.github.arlol.chorito.chores;
 
 import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import io.github.arlol.chorito.tools.ChoreContext;
 import io.github.arlol.chorito.tools.FilesSilent;
@@ -12,11 +13,29 @@ public class RenovateChore implements Chore {
 		Path renovateJson = context.resolve("renovate.json");
 		if (FilesSilent.exists(renovateJson)) {
 			var currentLines = FilesSilent.readAllLines(renovateJson);
-			var updatedLines = currentLines.stream().map(s -> {
+			boolean hasLabels = currentLines.stream()
+					.anyMatch(s -> s.contains("\"labels\""));
+			boolean hasSecurityLabel = currentLines.stream()
+					.anyMatch(s -> s.contains("\"addLabels\": [\"security\"]"));
+			var updatedLines = currentLines.stream().flatMap(s -> {
 				if (s.startsWith("  \"minimumReleaseAge\": \"4 days\",")) {
-					return "  \"minimumReleaseAge\": \"7 days\",";
+					return Stream.of("  \"minimumReleaseAge\": \"7 days\",");
 				}
-				return s;
+				if (s.equals("  ],") && !hasLabels) {
+					return Stream.of(
+							s,
+							"  \"labels\": [\"dependencies\"],",
+							"  \"addLabels\": [\"{{manager}}\"],"
+					);
+				}
+				if (s.equals("    \"minimumReleaseAge\": \"0 days\"")
+						&& !hasSecurityLabel) {
+					return Stream.of(
+							"    \"minimumReleaseAge\": \"0 days\",",
+							"    \"addLabels\": [\"security\"]"
+					);
+				}
+				return Stream.of(s);
 			}).toList();
 			if (!currentLines.equals(updatedLines)) {
 				FilesSilent.write(renovateJson, updatedLines, "\n");


### PR DESCRIPTION
## Summary
Updated the Renovate chore configuration to automatically label pull requests with dependency management information.

## Changes
- Added `"labels": ["dependencies"]` to apply a static "dependencies" label to all Renovate PRs
- Added `"addLabels": ["{{manager}}"]` to dynamically label PRs based on the package manager (e.g., npm, pip, gradle)

## Details
These configuration changes improve PR organization and filtering by:
- Consistently marking all dependency update PRs with a "dependencies" label for easy identification
- Automatically categorizing PRs by their package manager type, making it easier to track updates across different dependency ecosystems

https://claude.ai/code/session_01QDWpo6XTu2CwZ5q2Xvdqvf