### PR TITLE
Add Zig build file support to GitIgnore chore

### DIFF
--- a/src/main/java/io/github/arlol/chorito/chores/GitIgnoreChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/GitIgnoreChore.java
@@ -118,9 +118,18 @@ public class GitIgnoreChore implements Chore {
 			!/versions/**/*
 			""";
 
+	private static String GITIGNORE_ZIG = """
+			### Zig ###
+
+			.zig-cache/
+			zig-out/
+			*.o
+			""";
+
 	@Override
 	public ChoreContext doit(ChoreContext context) {
 		createPythonIgnore(context);
+		createZigIgnore(context);
 		createPackageJsonIgnore(context);
 		createYarnIgnore(context);
 		createMavenAndGradleIgnore(context);
@@ -137,6 +146,12 @@ public class GitIgnoreChore implements Chore {
 			String newGitignoreContent
 	) {
 		ExistingFileUpdater.update(gitignore, newGitignoreContent);
+	}
+
+	private void createZigIgnore(ChoreContext context) {
+		DirectoryStreams.buildZigDirs(context).forEach(dir -> {
+			updateExistingGitignore(dir.resolve(".gitignore"), GITIGNORE_ZIG);
+		});
 	}
 
 	private void createPythonIgnore(ChoreContext context) {

--- a/src/main/java/io/github/arlol/chorito/tools/DirectoryStreams.java
+++ b/src/main/java/io/github/arlol/chorito/tools/DirectoryStreams.java
@@ -104,6 +104,13 @@ public final class DirectoryStreams {
 				.map(MyPaths::getParent);
 	}
 
+	public static Stream<Path> buildZigDirs(ChoreContext context) {
+		return context.textFiles()
+				.stream()
+				.filter(file -> file.endsWith("build.zig"))
+				.map(MyPaths::getParent);
+	}
+
 	public static Stream<Path> packageJsonDirs(ChoreContext context) {
 		return context.textFiles()
 				.stream()

--- a/src/test/java/io/github/arlol/chorito/chores/GitIgnoreChoreTest.java
+++ b/src/test/java/io/github/arlol/chorito/chores/GitIgnoreChoreTest.java
@@ -94,6 +94,16 @@ public class GitIgnoreChoreTest {
 			# Add custom entries after this line to be preserved during automated updates
 			""";
 
+	private static String DEFAULT_BUILD_ZIG = """
+			### Zig ###
+
+			.zig-cache/
+			zig-out/
+			*.o
+
+			# Add custom entries after this line to be preserved during automated updates
+			""";
+
 	private static String OLD_POM_XML = """
 			# Created by chorito https://github.com/ArloL/chorito
 
@@ -131,6 +141,16 @@ public class GitIgnoreChoreTest {
 		Path gitignore = extension.root().resolve(".gitignore");
 		doit();
 		assertThat(FilesSilent.exists(gitignore)).isFalse();
+	}
+
+	@Test
+	public void testWithBuildZig() throws Exception {
+		FilesSilent.touch(extension.root().resolve("build.zig"));
+
+		doit();
+
+		assertThat(extension.root().resolve(".gitignore")).content()
+				.isEqualTo(DEFAULT_BUILD_ZIG);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
This PR adds support for automatically generating `.gitignore` entries for Zig projects by detecting `build.zig` files and applying appropriate ignore patterns.

## Key Changes
- Added `GITIGNORE_ZIG` constant with Zig-specific ignore patterns (`.zig-cache/`, `zig-out/`, `*.o`)
- Implemented `createZigIgnore()` method in `GitIgnoreChore` to process Zig projects
- Added `buildZigDirs()` stream method in `DirectoryStreams` to locate directories containing `build.zig` files
- Integrated Zig ignore creation into the main chore workflow
- Added comprehensive test case `testWithBuildZig()` to verify the functionality

## Implementation Details
- The Zig ignore patterns follow the same structure as existing language-specific patterns (Python, Maven, etc.)
- Detection is based on the presence of `build.zig` files, which is the standard Zig build configuration file
- The implementation maintains consistency with existing patterns for updating `.gitignore` files with preserved custom entries

https://claude.ai/code/session_0132VYq8c92iiJ4dsaByiB2o