### PR TITLE
Support Maven multi-module projects in Dependabot configuration

### DIFF
--- a/src/main/java/io/github/arlol/chorito/chores/DependabotChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/DependabotChore.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 
 import io.github.arlol.chorito.tools.ChoreContext;
 import io.github.arlol.chorito.tools.DependabotConfigFile;
+import io.github.arlol.chorito.tools.DirectoryStreams;
 import io.github.arlol.chorito.tools.FilesSilent;
 import io.github.arlol.chorito.tools.MyPaths;
 
@@ -34,7 +35,16 @@ public class DependabotChore implements Chore {
 			dependabotConfigFile = new DependabotConfigFile();
 		}
 
-		addEcosystemIfFileExists("pom.xml", "maven", context);
+		DirectoryStreams.rootMavenPoms(context)
+				.map(path -> getRootRelativePath(context.root(), path))
+				.distinct()
+				.forEach(
+						rootRelativePath -> dependabotConfigFile
+								.addEcosystemInDirectory(
+										"maven",
+										rootRelativePath
+								)
+				);
 		addEcosystemIfFileExists("Gemfile.lock", "bundler", context);
 		dependabotConfigFile.addEcosystemInDirectory("github-actions", "/");
 		addEcosystemIfFileNameMatches("(?i).*dockerfile", "docker", context);

--- a/src/test/java/io/github/arlol/chorito/chores/DependabotChoreTest.java
+++ b/src/test/java/io/github/arlol/chorito/chores/DependabotChoreTest.java
@@ -290,6 +290,55 @@ public class DependabotChoreTest {
 	}
 
 	@Test
+	public void testMavenMultiModuleProject() throws Exception {
+		FilesSilent.writeString(extension.root().resolve("pom.xml"), """
+				<project>
+				    <modelVersion>4.0.0</modelVersion>
+				    <groupId>com.example</groupId>
+				    <artifactId>parent</artifactId>
+				    <version>1.0-SNAPSHOT</version>
+				    <packaging>pom</packaging>
+				    <modules>
+				        <module>module-a</module>
+				    </modules>
+				</project>
+				""");
+		FilesSilent
+				.writeString(extension.root().resolve("module-a/pom.xml"), """
+						<project>
+						    <modelVersion>4.0.0</modelVersion>
+						    <parent>
+						        <groupId>com.example</groupId>
+						        <artifactId>parent</artifactId>
+						        <version>1.0-SNAPSHOT</version>
+						        <relativePath>../pom.xml</relativePath>
+						    </parent>
+						    <artifactId>module-a</artifactId>
+						</project>
+						""");
+
+		doit();
+
+		Path dependabot = extension.root().resolve(".github/dependabot.yml");
+		assertThat(dependabot).content().isEqualTo("""
+				version: 2
+				updates:
+				- package-ecosystem: "maven"
+				  directory: "/"
+				  schedule:
+				    interval: "monthly"
+				  cooldown:
+				    default-days: 7
+				- package-ecosystem: "github-actions"
+				  directory: "/"
+				  schedule:
+				    interval: "monthly"
+				  cooldown:
+				    default-days: 7
+				""");
+	}
+
+	@Test
 	public void testMaintainSettingsWithTrailingSlash() throws Exception {
 		// given
 		FilesSilent.touch(extension.root().resolve("subdir/pom.xml"));


### PR DESCRIPTION
## Summary
Enhanced the DependabotChore to properly handle Maven multi-module projects by detecting and configuring Dependabot for each root-level pom.xml file, rather than only checking for a single pom.xml at the project root.

## Key Changes
- Modified `DependabotChore.doit()` to use `DirectoryStreams.rootMavenPoms()` for discovering all root-level Maven pom.xml files in the project
- Each discovered pom.xml is now added as a separate Maven ecosystem entry in the Dependabot configuration with its relative path
- Deduplicated paths to avoid duplicate Dependabot entries using `.distinct()`
- Added test case `testMavenMultiModuleProject()` to verify correct behavior with a parent pom.xml and child module pom.xml

## Implementation Details
- The change leverages a new utility method `DirectoryStreams.rootMavenPoms()` to identify Maven project roots
- Uses `getRootRelativePath()` to convert absolute paths to root-relative paths for Dependabot configuration
- Maintains backward compatibility with single-module Maven projects while adding support for multi-module structures

https://claude.ai/code/session_0159XGKtT8HEG3qLSHZBmXvk