### PR TITLE
Only create .tool-versions in root Maven modules

### DIFF
--- a/src/main/java/io/github/arlol/chorito/chores/IdiomaticVersionFileChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/IdiomaticVersionFileChore.java
@@ -10,7 +10,7 @@ public class IdiomaticVersionFileChore implements Chore {
 
 	@Override
 	public ChoreContext doit(ChoreContext context) {
-		DirectoryStreams.javaDirs(context).forEach(javaDir -> {
+		DirectoryStreams.rootJavaDirs(context).forEach(javaDir -> {
 			FilesSilent.deleteIfExists(javaDir.resolve(".java-version"));
 			Path toolVersions = javaDir.resolve(".tool-versions");
 			if (!FilesSilent.exists(toolVersions)) {

--- a/src/main/java/io/github/arlol/chorito/tools/DirectoryStreams.java
+++ b/src/main/java/io/github/arlol/chorito/tools/DirectoryStreams.java
@@ -24,6 +24,16 @@ public final class DirectoryStreams {
 				.distinct();
 	}
 
+	public static Stream<Path> rootJavaDirs(ChoreContext context) {
+		return Stream
+				.of(
+						rootMavenPomsWithCode(context).map(MyPaths::getParent),
+						javaGradleDirsWithCode(context)
+				)
+				.flatMap(Function.identity())
+				.distinct();
+	}
+
 	public static Stream<Path> mavenPoms(ChoreContext context) {
 		return context.textFiles()
 				.stream()

--- a/src/test/java/io/github/arlol/chorito/chores/IdiomaticVersionFileChoreTest.java
+++ b/src/test/java/io/github/arlol/chorito/chores/IdiomaticVersionFileChoreTest.java
@@ -51,7 +51,8 @@ public class IdiomaticVersionFileChoreTest {
 	}
 
 	@Test
-	public void testMultiModuleMavenDoesNotCreateInChildModule() throws Exception {
+	public void testMultiModuleMavenDoesNotCreateInChildModule()
+			throws Exception {
 		FilesSilent.touch(extension.root().resolve("src/main/java/Main.java"));
 		FilesSilent.touch(extension.root().resolve("pom.xml"));
 		FilesSilent.writeString(extension.root().resolve("child/pom.xml"), """
@@ -61,12 +62,15 @@ public class IdiomaticVersionFileChoreTest {
 				</parent>
 				</project>
 				""");
-		FilesSilent.touch(extension.root().resolve("child/src/main/java/Child.java"));
+		FilesSilent.touch(
+				extension.root().resolve("child/src/main/java/Child.java")
+		);
 
 		doit();
 
 		assertThat(extension.root().resolve(".tool-versions")).exists();
-		assertThat(extension.root().resolve("child/.tool-versions")).doesNotExist();
+		assertThat(extension.root().resolve("child/.tool-versions"))
+				.doesNotExist();
 	}
 
 	@Test

--- a/src/test/java/io/github/arlol/chorito/chores/IdiomaticVersionFileChoreTest.java
+++ b/src/test/java/io/github/arlol/chorito/chores/IdiomaticVersionFileChoreTest.java
@@ -51,6 +51,25 @@ public class IdiomaticVersionFileChoreTest {
 	}
 
 	@Test
+	public void testMultiModuleMavenDoesNotCreateInChildModule() throws Exception {
+		FilesSilent.touch(extension.root().resolve("src/main/java/Main.java"));
+		FilesSilent.touch(extension.root().resolve("pom.xml"));
+		FilesSilent.writeString(extension.root().resolve("child/pom.xml"), """
+				<project>
+				<parent>
+				<relativePath>..</relativePath>
+				</parent>
+				</project>
+				""");
+		FilesSilent.touch(extension.root().resolve("child/src/main/java/Child.java"));
+
+		doit();
+
+		assertThat(extension.root().resolve(".tool-versions")).exists();
+		assertThat(extension.root().resolve("child/.tool-versions")).doesNotExist();
+	}
+
+	@Test
 	public void testGraal() throws Exception {
 		FilesSilent.touch(extension.root().resolve("src/main/java/Main.java"));
 		FilesSilent.writeString(


### PR DESCRIPTION
## Summary
Modified the IdiomaticVersionFileChore to only create `.tool-versions` files in root Java project directories, preventing creation in child modules of multi-module Maven projects.

## Key Changes
- Added new `rootJavaDirs()` method in `DirectoryStreams` that filters to only root-level Java directories (root Maven POMs with code and Java Gradle directories)
- Updated `IdiomaticVersionFileChore` to use `rootJavaDirs()` instead of `javaDirs()` when determining where to create `.tool-versions` files
- Added test case `testMultiModuleMavenDoesNotCreateInChildModule()` to verify that `.tool-versions` is created only in the parent module and not in child modules

## Implementation Details
The `rootJavaDirs()` method uses `rootMavenPomsWithCode()` to identify Maven projects, ensuring that only parent POMs (those with a `<parent>` reference) are excluded from having `.tool-versions` created in their directories. This prevents tool version conflicts in multi-module Maven projects where the parent module should be the single source of truth for version management.

https://claude.ai/code/session_01WxuTW63DvB8Q5VsFwvushF