### PR TITLE
Prevent VS Code settings generation in multi-module child projects

### DIFF
--- a/src/main/java/io/github/arlol/chorito/chores/VsCodeChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/VsCodeChore.java
@@ -19,7 +19,7 @@ public class VsCodeChore implements Chore {
 	@Override
 	public ChoreContext doit(ChoreContext context) {
 		Stream.of(
-				DirectoryStreams.javaDirs(context),
+				DirectoryStreams.rootJavaDirs(context),
 				context.textFiles()
 						.stream()
 						.map(MyPaths::getParent)

--- a/src/main/java/io/github/arlol/chorito/tools/DirectoryStreams.java
+++ b/src/main/java/io/github/arlol/chorito/tools/DirectoryStreams.java
@@ -28,7 +28,7 @@ public final class DirectoryStreams {
 		return Stream
 				.of(
 						rootMavenPomsWithCode(context).map(MyPaths::getParent),
-						javaGradleDirsWithCode(context)
+						rootJavaGradleDirs(context)
 				)
 				.flatMap(Function.identity())
 				.distinct();

--- a/src/test/java/io/github/arlol/chorito/chores/VsCodeChoreTest.java
+++ b/src/test/java/io/github/arlol/chorito/chores/VsCodeChoreTest.java
@@ -223,6 +223,52 @@ public class VsCodeChoreTest {
 	}
 
 	@Test
+	public void testMultiModuleChildDoesNotGetVsCodeSettings() {
+		// given — root pom has no code, child pom has relativePath + code
+		FilesSilent.touch(extension.root().resolve("pom.xml"));
+		FilesSilent.writeString(extension.root().resolve("module/pom.xml"), """
+				<project>
+				    <parent>
+				        <groupId>io.github.arlol</groupId>
+				        <artifactId>parent</artifactId>
+				        <version>1.0</version>
+				        <relativePath>../pom.xml</relativePath>
+				    </parent>
+				</project>
+				""");
+		FilesSilent.touch(
+				extension.root().resolve("module/src/main/java/Main.java")
+		);
+
+		// when
+		doit();
+
+		// then — root gets settings, child does not
+		Path rootExtensions = extension.root()
+				.resolve(".vscode/extensions.json");
+		assertThat(FilesSilent.exists(rootExtensions)).isTrue();
+		assertThat(rootExtensions).content().isEqualTo("""
+				{
+				    "recommendations": [
+				        "editorconfig.editorconfig",
+				        "vscjava.vscode-java-pack",
+				    ],
+				}
+				""");
+		assertThat(
+				FilesSilent.exists(
+						extension.root()
+								.resolve("module/.vscode/extensions.json")
+				)
+		).isFalse();
+		assertThat(
+				FilesSilent.exists(
+						extension.root().resolve("module/.vscode/settings.json")
+				)
+		).isFalse();
+	}
+
+	@Test
 	public void testWithExistingJavaNullAnalysisSettings() {
 		// given
 		FilesSilent.touch(extension.root().resolve("pom.xml"));


### PR DESCRIPTION
## Summary
This change ensures that VS Code configuration files are only generated in the root project of a multi-module Maven build, not in child modules. This prevents unwanted duplication of settings across module directories.

## Key Changes
- Updated `VsCodeChore.doit()` to use `DirectoryStreams.rootJavaDirs()` instead of `DirectoryStreams.javaDirs()`, ensuring only root-level Java directories are processed
- Updated `DirectoryStreams.rootJavaDirs()` to call `rootJavaGradleDirs()` instead of `javaGradleDirs()` for consistency with root-only processing
- Added comprehensive test case `testMultiModuleChildDoesNotGetVsCodeSettings()` that verifies:
  - Root project receives VS Code extensions configuration
  - Child modules with `<relativePath>` parent reference do not receive any VS Code settings

## Implementation Details
The fix leverages the existing `rootJavaDirs()` method which filters to only root-level Maven POMs (those with code but no parent POM), preventing the chore from generating settings in child module directories. This aligns with the principle that VS Code workspace configuration should be centralized at the project root.

https://claude.ai/code/session_01FRLPAbbgQJdgkmHpLvBwEK