### PR TITLE
Fix IntelliJ settings to only apply to root module in multi-module projects

### DIFF
--- a/src/main/java/io/github/arlol/chorito/chores/IntellijChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/IntellijChore.java
@@ -18,7 +18,7 @@ public class IntellijChore implements Chore {
 
 	@Override
 	public ChoreContext doit(ChoreContext context) {
-		DirectoryStreams.javaDirs(context).forEach(dir -> {
+		DirectoryStreams.rootJavaDirs(context).forEach(dir -> {
 			writeFromTemplate(context, dir, "eclipseCodeFormatter");
 			writeFromTemplate(context, dir, "saveactions_settings");
 			writeFromTemplate(context, dir, "codeStyles/codeStyleConfig");

--- a/src/test/java/io/github/arlol/chorito/chores/IntellijChoreTest.java
+++ b/src/test/java/io/github/arlol/chorito/chores/IntellijChoreTest.java
@@ -122,6 +122,41 @@ public class IntellijChoreTest {
 	}
 
 	@Test
+	public void testMultiModuleChildDoesNotGetIntellijSettings() {
+		// given — root pom has no code, child pom has relativePath + code
+		FilesSilent.touch(extension.root().resolve("pom.xml"));
+		FilesSilent.writeString(extension.root().resolve("module/pom.xml"), """
+				<project>
+				    <parent>
+				        <groupId>io.github.arlol</groupId>
+				        <artifactId>parent</artifactId>
+				        <version>1.0</version>
+				        <relativePath>../pom.xml</relativePath>
+				    </parent>
+				</project>
+				""");
+		FilesSilent.touch(
+				extension.root().resolve("module/src/main/java/Main.java")
+		);
+
+		// when
+		doit();
+
+		// then — root gets settings, child does not
+		assertThat(
+				extension.root().resolve(".idea/codeStyles/codeStyleConfig.xml")
+		).exists();
+		assertThat(
+				FilesSilent.exists(
+						extension.root()
+								.resolve(
+										"module/.idea/codeStyles/codeStyleConfig.xml"
+								)
+				)
+		).isFalse();
+	}
+
+	@Test
 	public void testAddLombok() throws Exception {
 
 		// given


### PR DESCRIPTION
## Summary
Modified the IntelliJ chore to only apply IDE settings to the root module in multi-module Maven projects, preventing duplicate or conflicting settings in child modules.

## Key Changes
- Changed `DirectoryStreams.javaDirs()` to `DirectoryStreams.rootJavaDirs()` in `IntellijChore.doit()` to filter for only the root Java directory
- Added test case `testMultiModuleChildDoesNotGetIntellijSettings()` to verify that IntelliJ settings are created in the root module but not in child modules with `relativePath` parent references

## Implementation Details
The fix ensures that when processing multi-module Maven projects, IntelliJ configuration files (code style settings, Eclipse formatter config, save actions) are only written to the root project directory. This prevents child modules from receiving duplicate IDE settings and maintains a cleaner project structure where IDE configuration is centralized at the root level.

https://claude.ai/code/session_01B2huPQa1Gw1aXXSjCvWZan