### PR TITLE
Remove WindowsImageHeapProviderFeature step from Graal windows workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -151,8 +151,6 @@ jobs:
         cache: maven
         distribution: graalvm
         java-version-file: .tool-versions
-    - name: Remove WindowsImageHeapProviderFeature
-      run: '& 7z d "$env:JAVA_HOME\lib\svm\builder\svm.jar" com/oracle/svm/core/windows/WindowsImageHeapProviderFeature.class'
     - name: Build with Maven
       run: |
         .\mvnw --batch-mode -Dsha1="$env:GITHUB_SHA" -Drevision="$env:REVISION" verify

--- a/src/test/resources/io/github/arlol/chorito/github-actions/upx-removal-output.yaml
+++ b/src/test/resources/io/github/arlol/chorito/github-actions/upx-removal-output.yaml
@@ -145,8 +145,6 @@ jobs:
         cache: maven
         distribution: graalvm
         java-version-file: .tool-versions
-    - name: Remove WindowsImageHeapProviderFeature
-      run: '& 7z d "$env:JAVA_HOME\lib\svm\builder\svm.jar" com/oracle/svm/core/windows/WindowsImageHeapProviderFeature.class'
     - name: Build with Maven
       run: |
         .\mvnw --batch-mode -Dsha1="$env:GITHUB_SHA" -Drevision="$env:REVISION" verify


### PR DESCRIPTION
This workaround is no longer necessary. Removing it from the template
means updateGraalSteps will no longer propagate it to downstream projects.

https://claude.ai/code/session_01Pqkt8zW9jPzY7v6GP8doW5