### PR TITLE
Add Jekyll support to GitIgnoreChore

### DIFF
--- a/src/main/java/io/github/arlol/chorito/chores/GitIgnoreChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/GitIgnoreChore.java
@@ -126,10 +126,17 @@ public class GitIgnoreChore implements Chore {
 			*.o
 			""";
 
+	private static String GITIGNORE_JEKYLL = """
+			### Jekyll ###
+
+			/_site/
+			""";
+
 	@Override
 	public ChoreContext doit(ChoreContext context) {
 		createPythonIgnore(context);
 		createZigIgnore(context);
+		createJekyllIgnore(context);
 		createPackageJsonIgnore(context);
 		createYarnIgnore(context);
 		createMavenAndGradleIgnore(context);
@@ -151,6 +158,15 @@ public class GitIgnoreChore implements Chore {
 	private void createZigIgnore(ChoreContext context) {
 		DirectoryStreams.buildZigDirs(context).forEach(dir -> {
 			updateExistingGitignore(dir.resolve(".gitignore"), GITIGNORE_ZIG);
+		});
+	}
+
+	private void createJekyllIgnore(ChoreContext context) {
+		DirectoryStreams.jekyllGemfileDirs(context).forEach(dir -> {
+			updateExistingGitignore(
+					dir.resolve(".gitignore"),
+					GITIGNORE_JEKYLL
+			);
 		});
 	}
 

--- a/src/main/java/io/github/arlol/chorito/tools/DirectoryStreams.java
+++ b/src/main/java/io/github/arlol/chorito/tools/DirectoryStreams.java
@@ -132,6 +132,17 @@ public final class DirectoryStreams {
 				.map(MyPaths::getParent);
 	}
 
+	public static Stream<Path> jekyllGemfileDirs(ChoreContext context) {
+		return context.textFiles()
+				.stream()
+				.filter(file -> file.endsWith("Gemfile"))
+				.filter(
+						gemfile -> FilesSilent.readString(gemfile)
+								.contains("jekyll")
+				)
+				.map(MyPaths::getParent);
+	}
+
 	public static Stream<Path> dotYarnDirs(ChoreContext context) {
 		return context.textFiles()
 				.stream()

--- a/src/test/java/io/github/arlol/chorito/chores/GitIgnoreChoreTest.java
+++ b/src/test/java/io/github/arlol/chorito/chores/GitIgnoreChoreTest.java
@@ -104,6 +104,14 @@ public class GitIgnoreChoreTest {
 			# Add custom entries after this line to be preserved during automated updates
 			""";
 
+	private static String DEFAULT_JEKYLL_GEMFILE = """
+			### Jekyll ###
+
+			/_site/
+
+			# Add custom entries after this line to be preserved during automated updates
+			""";
+
 	private static String OLD_POM_XML = """
 			# Created by chorito https://github.com/ArloL/chorito
 
@@ -141,6 +149,32 @@ public class GitIgnoreChoreTest {
 		Path gitignore = extension.root().resolve(".gitignore");
 		doit();
 		assertThat(FilesSilent.exists(gitignore)).isFalse();
+	}
+
+	@Test
+	public void testWithJekyllGemfile() throws Exception {
+		FilesSilent.writeString(
+				extension.root().resolve("Gemfile"),
+				"gem 'jekyll'"
+		);
+
+		doit();
+
+		assertThat(extension.root().resolve(".gitignore")).content()
+				.isEqualTo(DEFAULT_JEKYLL_GEMFILE);
+	}
+
+	@Test
+	public void testWithNonJekyllGemfile() throws Exception {
+		FilesSilent.writeString(
+				extension.root().resolve("Gemfile"),
+				"gem 'rails'"
+		);
+
+		doit();
+
+		assertThat(FilesSilent.exists(extension.root().resolve(".gitignore")))
+				.isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
This PR adds automatic `.gitignore` generation for Jekyll projects by detecting Gemfiles that contain the Jekyll gem dependency.

## Key Changes
- Added `GITIGNORE_JEKYLL` constant with Jekyll-specific ignore patterns (`/_site/`)
- Implemented `createJekyllIgnore()` method in `GitIgnoreChore` to handle Jekyll projects
- Added `jekyllGemfileDirs()` stream method in `DirectoryStreams` that:
  - Filters for `Gemfile` files
  - Checks if the file contains the "jekyll" gem dependency
  - Returns parent directories of matching Gemfiles
- Added comprehensive test coverage:
  - `testWithJekyllGemfile()` - verifies `.gitignore` is created for Jekyll projects
  - `testWithNonJekyllGemfile()` - ensures non-Jekyll Gemfiles are ignored

## Implementation Details
The Jekyll detection is content-based rather than filename-based, ensuring only actual Jekyll projects receive Jekyll-specific ignore rules. This prevents false positives for other Ruby projects that happen to have a Gemfile.

https://claude.ai/code/session_01E17pJiA4p5FSTKyyL7xX9K