### PR TITLE
Upgrade Maven to 3.9.15 in MavenWrapperChore

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,4 +1,4 @@
 wrapperVersion=3.3.4
 distributionType=bin
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/src/main/java/io/github/arlol/chorito/chores/MavenWrapperChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/MavenWrapperChore.java
@@ -20,7 +20,7 @@ public class MavenWrapperChore implements Chore {
 	private static String DEFAULT_PROPERTIES = """
 			wrapperVersion=3.3.4
 			distributionType=bin
-			distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+			distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
 			wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar
 			""";
 
@@ -42,7 +42,7 @@ public class MavenWrapperChore implements Chore {
 								"mvn",
 								"-N",
 								"wrapper:3.3.4:wrapper",
-								"-Dmaven=3.9.14",
+								"-Dmaven=3.9.15",
 								"-Dtype=bin"
 						)
 								.inheritIO()
@@ -64,7 +64,7 @@ public class MavenWrapperChore implements Chore {
 									"./mvnw",
 									"-N",
 									"wrapper:3.3.4:wrapper",
-									"-Dmaven=3.9.14",
+									"-Dmaven=3.9.15",
 									"-Dtype=bin"
 							)
 									.inheritIO()


### PR DESCRIPTION
## Summary
Updates the Maven version used by the Maven Wrapper from 3.9.14 to 3.9.15 across the codebase.

## Key Changes
- Updated `DEFAULT_PROPERTIES` distribution URL to point to Maven 3.9.15
- Updated Maven version parameter in the Windows command execution from 3.9.14 to 3.9.15
- Updated Maven version parameter in the Unix/Linux command execution from 3.9.14 to 3.9.15

## Details
This change ensures that the MavenWrapperChore will provision Maven 3.9.15 when setting up or updating Maven wrapper configurations, keeping the project aligned with the latest stable Maven release.

https://claude.ai/code/session_01BK3NWNcxtQFpA6Y3x9SVPs