### PR TITLE
Enable Dependabot updates for Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,9 @@ updates:
     interval: "monthly"
   cooldown:
     default-days: 7
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
## Summary
This change enables Dependabot to automatically check for and create pull requests for Go module dependency updates.

## Key Changes
- Added Go module (`gomod`) package ecosystem configuration to Dependabot
- Set monthly update schedule for Go dependencies
- Configured 7-day cooldown period between Dependabot PRs for Go modules

## Implementation Details
The new configuration mirrors the existing setup for other package ecosystems, ensuring consistent dependency management practices across the project. Go module updates will be checked monthly with a default 7-day cooldown between automated pull requests.

https://claude.ai/code/session_01DLpdDtryMcb7LLVGUZ315S