### PR TITLE
Add Go module support to Dependabot configuration

### DIFF
--- a/src/main/java/io/github/arlol/chorito/chores/DependabotChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/DependabotChore.java
@@ -51,6 +51,7 @@ public class DependabotChore implements Chore {
 		addEcosystemIfFileExists("Pipfile", "pip", context);
 		addEcosystemIfFileExists("pyproject.toml", "pip", context);
 		addEcosystemIfFileExists("package.json", "npm", context);
+		addEcosystemIfFileExists("go.mod", "go", context);
 		addEcosystemIfFileExists("build.gradle", "gradle", context);
 		addEcosystemIfFileExists(".terraform.lock.hcl", "terraform", context);
 		addEcosystemIfFileExists(

--- a/src/test/java/io/github/arlol/chorito/chores/DependabotChoreTest.java
+++ b/src/test/java/io/github/arlol/chorito/chores/DependabotChoreTest.java
@@ -170,6 +170,57 @@ public class DependabotChoreTest {
 	}
 
 	@Test
+	public void testGoMod() throws Exception {
+		FilesSilent.touch(extension.root().resolve("go.mod"));
+
+		doit();
+
+		Path dependabot = extension.root().resolve(".github/dependabot.yml");
+		assertThat(dependabot).content().isEqualTo("""
+				version: 2
+				updates:
+				- package-ecosystem: "github-actions"
+				  directory: "/"
+				  schedule:
+				    interval: "monthly"
+				  cooldown:
+				    default-days: 7
+				- package-ecosystem: "go"
+				  directory: "/"
+				  schedule:
+				    interval: "monthly"
+				  cooldown:
+				    default-days: 7
+				""");
+	}
+
+	@Test
+	public void testGoModInSubdirectory() throws Exception {
+		FilesSilent.createDirectories(extension.root().resolve("services/api"));
+		FilesSilent.touch(extension.root().resolve("services/api/go.mod"));
+
+		doit();
+
+		Path dependabot = extension.root().resolve(".github/dependabot.yml");
+		assertThat(dependabot).content().isEqualTo("""
+				version: 2
+				updates:
+				- package-ecosystem: "github-actions"
+				  directory: "/"
+				  schedule:
+				    interval: "monthly"
+				  cooldown:
+				    default-days: 7
+				- package-ecosystem: "go"
+				  directory: "/services/api/"
+				  schedule:
+				    interval: "monthly"
+				  cooldown:
+				    default-days: 7
+				""");
+	}
+
+	@Test
 	public void testKeepExistingSettings() throws Exception {
 		Path dependabot = extension.root().resolve(".github/dependabot.yml");
 		FilesSilent.writeString(dependabot, """


### PR DESCRIPTION
## Summary
This PR adds support for Go modules (`go.mod`) to the Dependabot chore, enabling automatic dependency updates for Go projects.

## Key Changes
- Added detection of `go.mod` files in the DependabotChore to automatically configure the "go" package ecosystem
- The implementation supports both root-level and subdirectory `go.mod` files, with the directory path correctly reflected in the generated Dependabot configuration
- Added comprehensive test coverage with two test cases:
  - `testGoMod()`: Verifies Go ecosystem is added when `go.mod` exists in the root directory
  - `testGoModInSubdirectory()`: Verifies correct directory path handling when `go.mod` is in a subdirectory (e.g., `services/api/`)

## Implementation Details
The change follows the existing pattern used for other package ecosystems (pip, npm, gradle, terraform) by leveraging the `addEcosystemIfFileExists()` method to detect `go.mod` files and register the "go" ecosystem with appropriate scheduling and cooldown settings.

https://claude.ai/code/session_01SzeFW5DFH46hS1NYdKTnSz