### PR TITLE
Always include actions in CodeQL analysis languages

### DIFF
--- a/src/main/java/io/github/arlol/chorito/chores/CodeQlAnalysisChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/CodeQlAnalysisChore.java
@@ -46,17 +46,7 @@ public class CodeQlAnalysisChore implements Chore {
 				)) {
 			languages.add("python");
 		}
-		Path workflowsLocation = context.resolve(".github/workflows");
-		if (context.textFiles()
-				.stream()
-				.anyMatch(path -> path.startsWith(workflowsLocation))) {
-			languages.add("actions");
-		}
-
-		// there is no code in this repository that can be analyzed
-		if (languages.isEmpty()) {
-			return context;
-		}
+		languages.add("actions");
 
 		RandomCronBuilder randomCronBuilder = new RandomCronBuilder(
 				context.randomGenerator()

--- a/src/test/java/io/github/arlol/chorito/chores/CodeQlAnalysisChoreTest.java
+++ b/src/test/java/io/github/arlol/chorito/chores/CodeQlAnalysisChoreTest.java
@@ -27,6 +27,27 @@ public class CodeQlAnalysisChoreTest {
 	}
 
 	@Test
+	public void testEmptyGithubProject() throws Exception {
+		ChoreContext context = extension.choreContext()
+				.toBuilder()
+				.remotes(List.of("https://github.com/example/example"))
+				.randomGenerator(new FakeRandomGenerator())
+				.build();
+
+		new CodeQlAnalysisChore().doit(context);
+
+		Path workflow = context
+				.resolve(".github/workflows/codeql-analysis.yaml");
+		assertTrue(FilesSilent.exists(workflow));
+		assertThat(removeVersions(FilesSilent.readString(workflow))).isEqualTo(
+				removeVersions(
+						ClassPathFiles
+								.readString("codeql/actions-expected.yaml")
+				)
+		);
+	}
+
+	@Test
 	public void testJava() throws Exception {
 		FilesSilent.touch(extension.root().resolve("pom.xml"));
 

--- a/src/test/resources/io/github/arlol/chorito/codeql/expected.yaml
+++ b/src/test/resources/io/github/arlol/chorito/codeql/expected.yaml
@@ -46,6 +46,7 @@ jobs:
       matrix:
         language:
         - java-kotlin
+        - actions
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:

--- a/src/test/resources/io/github/arlol/chorito/codeql/java-expected.yaml
+++ b/src/test/resources/io/github/arlol/chorito/codeql/java-expected.yaml
@@ -48,6 +48,7 @@ jobs:
       matrix:
         language:
         - java-kotlin
+        - actions
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:

--- a/src/test/resources/io/github/arlol/chorito/codeql/javascript-expected.yaml
+++ b/src/test/resources/io/github/arlol/chorito/codeql/javascript-expected.yaml
@@ -48,6 +48,7 @@ jobs:
       matrix:
         language:
         - javascript-typescript
+        - actions
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:

--- a/src/test/resources/io/github/arlol/chorito/codeql/python-expected.yaml
+++ b/src/test/resources/io/github/arlol/chorito/codeql/python-expected.yaml
@@ -48,6 +48,7 @@ jobs:
       matrix:
         language:
         - python
+        - actions
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:


### PR DESCRIPTION
## Summary
This change modifies the CodeQL Analysis chore to always include "actions" as an analyzed language, regardless of whether GitHub Actions workflows already exist in the repository.

## Key Changes
- **Simplified language detection logic**: Removed the conditional check that only added "actions" language if workflows already existed in `.github/workflows`
- **Always analyze actions**: The "actions" language is now unconditionally added to the CodeQL analysis matrix
- **Updated test expectations**: All expected workflow YAML files now include "actions" in the language matrix
- **Added new test case**: Added `testEmptyGithubProject()` to verify CodeQL workflow generation works correctly for repositories with no existing code or workflows

## Implementation Details
The change simplifies the `CodeQlAnalysisChore.doit()` method by removing the logic that checked for existing workflow files before adding "actions" to the language list. This ensures that GitHub Actions code is always analyzed by CodeQL, even in new or empty repositories. The removal of the early return condition when `languages.isEmpty()` is no longer needed since "actions" is always added.

https://claude.ai/code/session_01H9AGe2TwEuwfgJBeaTpjmS