### PR TITLE
Upgrade Maven from 3.9.15 to 3.9.16

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,4 +1,4 @@
 wrapperVersion=3.3.4
 distributionType=bin
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/src/main/java/io/github/arlol/chorito/chores/MavenWrapperChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/MavenWrapperChore.java
@@ -20,7 +20,7 @@ public class MavenWrapperChore implements Chore {
 	private static String DEFAULT_PROPERTIES = """
 			wrapperVersion=3.3.4
 			distributionType=bin
-			distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
+			distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
 			wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar
 			""";
 
@@ -42,7 +42,7 @@ public class MavenWrapperChore implements Chore {
 								"mvn",
 								"-N",
 								"wrapper:3.3.4:wrapper",
-								"-Dmaven=3.9.15",
+								"-Dmaven=3.9.16",
 								"-Dtype=bin"
 						)
 								.inheritIO()
@@ -64,7 +64,7 @@ public class MavenWrapperChore implements Chore {
 									"./mvnw",
 									"-N",
 									"wrapper:3.3.4:wrapper",
-									"-Dmaven=3.9.15",
+									"-Dmaven=3.9.16",
 									"-Dtype=bin"
 							)
 									.inheritIO()


### PR DESCRIPTION
## Summary
Updates the Maven version used by the Maven Wrapper chore from 3.9.15 to 3.9.16.

## Key Changes
- Updated `DEFAULT_PROPERTIES` distribution URL to point to Maven 3.9.16
- Updated Maven version parameter in the wrapper initialization command for Unix/Linux systems
- Updated Maven version parameter in the wrapper initialization command for Windows systems

## Details
This change updates all references to the Maven version across the `MavenWrapperChore` class, ensuring consistency between the default properties configuration and the wrapper commands executed on both Unix-like and Windows platforms.

https://claude.ai/code/session_01Bgaj1Vxy9mKK47sqJeUzDv