### PR TITLE
Update Dependabot Go ecosystem from "go" to "gomod"

### DIFF
--- a/src/main/java/io/github/arlol/chorito/chores/DependabotChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/DependabotChore.java
@@ -45,7 +45,6 @@ public class DependabotChore implements Chore {
 										rootRelativePath
 								)
 				);
-		dependabotConfigFile.renameEcosystem("go", "gomod");
 		addEcosystemIfFileExists("Gemfile.lock", "bundler", context);
 		dependabotConfigFile.addEcosystemInDirectory("github-actions", "/");
 		addEcosystemIfFileNameMatches("(?i).*dockerfile", "docker", context);

--- a/src/main/java/io/github/arlol/chorito/chores/DependabotChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/DependabotChore.java
@@ -45,13 +45,14 @@ public class DependabotChore implements Chore {
 										rootRelativePath
 								)
 				);
+		dependabotConfigFile.renameEcosystem("go", "gomod");
 		addEcosystemIfFileExists("Gemfile.lock", "bundler", context);
 		dependabotConfigFile.addEcosystemInDirectory("github-actions", "/");
 		addEcosystemIfFileNameMatches("(?i).*dockerfile", "docker", context);
 		addEcosystemIfFileExists("Pipfile", "pip", context);
 		addEcosystemIfFileExists("pyproject.toml", "pip", context);
 		addEcosystemIfFileExists("package.json", "npm", context);
-		addEcosystemIfFileExists("go.mod", "go", context);
+		addEcosystemIfFileExists("go.mod", "gomod", context);
 		addEcosystemIfFileExists("build.gradle", "gradle", context);
 		addEcosystemIfFileExists(".terraform.lock.hcl", "terraform", context);
 		addEcosystemIfFileExists(

--- a/src/main/java/io/github/arlol/chorito/tools/DependabotConfigFile.java
+++ b/src/main/java/io/github/arlol/chorito/tools/DependabotConfigFile.java
@@ -88,6 +88,16 @@ public class DependabotConfigFile {
 		getUpdates().add(newMap(nodes));
 	}
 
+	public void renameEcosystem(String from, String to) {
+		getUpdatesAsMappingNode().filter(update -> {
+			return scalarValue(getKeyAsNode(update, "package-ecosystem"))
+					.filter(from::equals)
+					.isPresent();
+		}).forEach(update -> {
+			setKey(update, "package-ecosystem", newScalar(to));
+		});
+	}
+
 	public void changeDailyScheduleToMonthly() {
 		getYamlPath(root.orElseThrow(), "/updates/schedule[interval=daily]")
 				.forEach(node -> {

--- a/src/main/java/io/github/arlol/chorito/tools/DependabotConfigFile.java
+++ b/src/main/java/io/github/arlol/chorito/tools/DependabotConfigFile.java
@@ -88,16 +88,6 @@ public class DependabotConfigFile {
 		getUpdates().add(newMap(nodes));
 	}
 
-	public void renameEcosystem(String from, String to) {
-		getUpdatesAsMappingNode().filter(update -> {
-			return scalarValue(getKeyAsNode(update, "package-ecosystem"))
-					.filter(from::equals)
-					.isPresent();
-		}).forEach(update -> {
-			setKey(update, "package-ecosystem", newScalar(to));
-		});
-	}
-
 	public void changeDailyScheduleToMonthly() {
 		getYamlPath(root.orElseThrow(), "/updates/schedule[interval=daily]")
 				.forEach(node -> {

--- a/src/test/java/io/github/arlol/chorito/chores/DependabotChoreTest.java
+++ b/src/test/java/io/github/arlol/chorito/chores/DependabotChoreTest.java
@@ -221,47 +221,6 @@ public class DependabotChoreTest {
 	}
 
 	@Test
-	public void testRenameGoToGomod() throws Exception {
-		FilesSilent.touch(extension.root().resolve("go.mod"));
-		Path dependabot = extension.root().resolve(".github/dependabot.yml");
-		FilesSilent.writeString(dependabot, """
-				version: 2
-				updates:
-				  - package-ecosystem: "github-actions"
-				    directory: "/"
-				    schedule:
-				      interval: "monthly"
-				    cooldown:
-				      default-days: 7
-				  - package-ecosystem: "go"
-				    directory: "/"
-				    schedule:
-				      interval: "monthly"
-				    cooldown:
-				      default-days: 7
-				""");
-
-		doit();
-
-		assertThat(dependabot).content().isEqualTo("""
-				version: 2
-				updates:
-				- package-ecosystem: "github-actions"
-				  directory: "/"
-				  schedule:
-				    interval: "monthly"
-				  cooldown:
-				    default-days: 7
-				- package-ecosystem: "gomod"
-				  directory: "/"
-				  schedule:
-				    interval: "monthly"
-				  cooldown:
-				    default-days: 7
-				""");
-	}
-
-	@Test
 	public void testKeepExistingSettings() throws Exception {
 		Path dependabot = extension.root().resolve(".github/dependabot.yml");
 		FilesSilent.writeString(dependabot, """

--- a/src/test/java/io/github/arlol/chorito/chores/DependabotChoreTest.java
+++ b/src/test/java/io/github/arlol/chorito/chores/DependabotChoreTest.java
@@ -185,7 +185,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
-				- package-ecosystem: "go"
+				- package-ecosystem: "gomod"
 				  directory: "/"
 				  schedule:
 				    interval: "monthly"
@@ -211,8 +211,49 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
-				- package-ecosystem: "go"
+				- package-ecosystem: "gomod"
 				  directory: "/services/api/"
+				  schedule:
+				    interval: "monthly"
+				  cooldown:
+				    default-days: 7
+				""");
+	}
+
+	@Test
+	public void testRenameGoToGomod() throws Exception {
+		FilesSilent.touch(extension.root().resolve("go.mod"));
+		Path dependabot = extension.root().resolve(".github/dependabot.yml");
+		FilesSilent.writeString(dependabot, """
+				version: 2
+				updates:
+				  - package-ecosystem: "github-actions"
+				    directory: "/"
+				    schedule:
+				      interval: "monthly"
+				    cooldown:
+				      default-days: 7
+				  - package-ecosystem: "go"
+				    directory: "/"
+				    schedule:
+				      interval: "monthly"
+				    cooldown:
+				      default-days: 7
+				""");
+
+		doit();
+
+		assertThat(dependabot).content().isEqualTo("""
+				version: 2
+				updates:
+				- package-ecosystem: "github-actions"
+				  directory: "/"
+				  schedule:
+				    interval: "monthly"
+				  cooldown:
+				    default-days: 7
+				- package-ecosystem: "gomod"
+				  directory: "/"
 				  schedule:
 				    interval: "monthly"
 				  cooldown:


### PR DESCRIPTION
## Summary
Updates the Dependabot chore to use the correct `gomod` package ecosystem identifier instead of the deprecated `go` identifier for Go module dependencies.

## Key Changes
- Added `renameEcosystem()` method to `DependabotConfigFile` to rename existing ecosystem entries in dependabot.yml files
- Updated `DependabotChore` to call `renameEcosystem("go", "gomod")` to migrate any existing "go" entries to "gomod"
- Changed the ecosystem identifier from `"go"` to `"gomod"` when adding new Go module configurations
- Added test case `testRenameGoToGomod()` to verify that existing "go" ecosystem entries are correctly renamed to "gomod"

## Implementation Details
The `renameEcosystem()` method filters through all update entries in the dependabot configuration, finds those matching the source ecosystem name, and updates them to the target ecosystem name. This ensures backward compatibility by automatically migrating existing configurations while new configurations use the correct identifier from the start.

https://claude.ai/code/session_015iW4T3f4cdugbPRNGZ8TC2