### PR TITLE
Create .npmrc with min-release-age=7 for npm projects

### DIFF
--- a/src/main/java/io/github/arlol/chorito/chores/NpmrcChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/NpmrcChore.java
@@ -1,0 +1,56 @@
+package io.github.arlol.chorito.chores;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import io.github.arlol.chorito.tools.ChoreContext;
+import io.github.arlol.chorito.tools.DirectoryStreams;
+import io.github.arlol.chorito.tools.FilesSilent;
+
+public class NpmrcChore implements Chore {
+
+	private static final String MIN_RELEASE_AGE = "min-release-age";
+
+	@Override
+	public ChoreContext doit(ChoreContext context) {
+		DirectoryStreams.packageJsonDirs(context).forEach(dir -> {
+			Path npmrc = dir.resolve(".npmrc");
+			if (!FilesSilent.exists(npmrc)) {
+				FilesSilent.writeString(npmrc, MIN_RELEASE_AGE + "=7\n");
+				return;
+			}
+			List<String> lines = FilesSilent.readAllLines(npmrc);
+			boolean changed = false;
+			boolean found = false;
+			for (int i = 0; i < lines.size(); i++) {
+				String[] keyValue = lines.get(i).split("=", 2);
+				if (!keyValue[0].strip().equals(MIN_RELEASE_AGE)) {
+					continue;
+				}
+				found = true;
+				if (keyValue.length == 2 && isAtLeastSeven(keyValue[1])) {
+					continue;
+				}
+				lines.set(i, MIN_RELEASE_AGE + "=7");
+				changed = true;
+			}
+			if (!found) {
+				lines.add(MIN_RELEASE_AGE + "=7");
+				changed = true;
+			}
+			if (changed) {
+				FilesSilent.write(npmrc, lines, "\n");
+			}
+		});
+		return context;
+	}
+
+	private boolean isAtLeastSeven(String value) {
+		try {
+			return Integer.parseInt(value.strip()) >= 7;
+		} catch (NumberFormatException e) {
+			return true;
+		}
+	}
+
+}

--- a/src/main/java/io/github/arlol/chorito/commands/ChoritoCommand.java
+++ b/src/main/java/io/github/arlol/chorito/commands/ChoritoCommand.java
@@ -29,6 +29,7 @@ public class ChoritoCommand {
 				new DockerfileChore(),
 				new DockerIgnoreChore(),
 				new DependabotChore(),
+				new NpmrcChore(),
 				new CodeQlAnalysisChore(),
 				new GitHubActionChore(),
 				new GitIgnoreChore(),

--- a/src/test/java/io/github/arlol/chorito/chores/NpmrcChoreTest.java
+++ b/src/test/java/io/github/arlol/chorito/chores/NpmrcChoreTest.java
@@ -1,0 +1,108 @@
+package io.github.arlol.chorito.chores;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.github.arlol.chorito.tools.FileSystemExtension;
+import io.github.arlol.chorito.tools.FilesSilent;
+
+public class NpmrcChoreTest {
+
+	@RegisterExtension
+	final FileSystemExtension extension = new FileSystemExtension();
+
+	private void doit() {
+		new NpmrcChore().doit(extension.choreContext());
+	}
+
+	@Test
+	public void testWithNothing() {
+		doit();
+
+		Path npmrc = extension.choreContext().resolve(".npmrc");
+		assertThat(npmrc).doesNotExist();
+	}
+
+	@Test
+	public void testCreatesNpmrc() throws Exception {
+		FilesSilent.touch(extension.choreContext().resolve("package.json"));
+
+		doit();
+
+		Path npmrc = extension.choreContext().resolve(".npmrc");
+		assertThat(npmrc).content().isEqualTo("min-release-age=7\n");
+	}
+
+	@Test
+	public void testCreatesNestedNpmrc() throws Exception {
+		FilesSilent
+				.touch(extension.choreContext().resolve("nested/package.json"));
+
+		doit();
+
+		Path npmrc = extension.choreContext().resolve("nested/.npmrc");
+		assertThat(npmrc).content().isEqualTo("min-release-age=7\n");
+	}
+
+	@Test
+	public void testPreservesExistingSettings() throws Exception {
+		FilesSilent.touch(extension.choreContext().resolve("package.json"));
+		FilesSilent.writeString(
+				extension.choreContext().resolve(".npmrc"),
+				"registry=https://registry.example.com/\nsave-exact=true\n"
+		);
+
+		doit();
+
+		Path npmrc = extension.choreContext().resolve(".npmrc");
+		assertThat(npmrc).content().isEqualTo("""
+				registry=https://registry.example.com/
+				save-exact=true
+				min-release-age=7
+				""");
+	}
+
+	@Test
+	public void testBumpsTooLowValue() throws Exception {
+		FilesSilent.touch(extension.choreContext().resolve("package.json"));
+		FilesSilent.writeString(
+				extension.choreContext().resolve(".npmrc"),
+				"min-release-age=3\n"
+		);
+
+		doit();
+
+		Path npmrc = extension.choreContext().resolve(".npmrc");
+		assertThat(npmrc).content().isEqualTo("min-release-age=7\n");
+	}
+
+	@Test
+	public void testKeepsHigherValue() throws Exception {
+		FilesSilent.touch(extension.choreContext().resolve("package.json"));
+		FilesSilent.writeString(
+				extension.choreContext().resolve(".npmrc"),
+				"min-release-age=14\n"
+		);
+
+		doit();
+
+		Path npmrc = extension.choreContext().resolve(".npmrc");
+		assertThat(npmrc).content().isEqualTo("min-release-age=14\n");
+	}
+
+	@Test
+	public void testStability() throws Exception {
+		FilesSilent.touch(extension.choreContext().resolve("package.json"));
+
+		doit();
+		doit();
+
+		Path npmrc = extension.choreContext().resolve(".npmrc");
+		assertThat(npmrc).content().isEqualTo("min-release-age=7\n");
+	}
+
+}


### PR DESCRIPTION
Aligns npm installs with the 7 day cooldown already enforced via renovate minimumReleaseAge and dependabot cooldown. For every directory containing a package.json the new NpmrcChore creates a .npmrc with min-release-age=7, appends the setting to existing files without touching other entries, and bumps values below 7.


Claude-Session: https://claude.ai/code/session_01XuS6pU2VfnKGdWtxwtcn1e