### PR TITLE
Add GitHub CodeQL Action grouping to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     interval: "monthly"
   cooldown:
     default-days: 7
+  groups:
+    github-codeql-action:
+      patterns:
+      - "github/codeql-action*"
 - package-ecosystem: "devcontainers"
   directory: "/"
   schedule:

--- a/src/main/java/io/github/arlol/chorito/chores/DependabotChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/DependabotChore.java
@@ -65,6 +65,7 @@ public class DependabotChore implements Chore {
 
 		dependabotConfigFile.changeDailyScheduleToMonthly();
 		dependabotConfigFile.addCooldownIfMissing();
+		dependabotConfigFile.addGitHubCodeQlActionGroupIfMissing();
 
 		FilesSilent.writeString(dependabotYml, dependabotConfigFile.asString());
 

--- a/src/main/java/io/github/arlol/chorito/tools/DependabotConfigFile.java
+++ b/src/main/java/io/github/arlol/chorito/tools/DependabotConfigFile.java
@@ -95,6 +95,33 @@ public class DependabotConfigFile {
 				});
 	}
 
+	public void addGitHubCodeQlActionGroupIfMissing() {
+		getUpdatesAsMappingNode().forEach(update -> {
+			if (scalarValue(getKeyAsNode(update, "package-ecosystem"))
+					.filter("github-actions"::equals)
+					.isEmpty()) {
+				return;
+			}
+			var group = newMap(
+					newTuple(
+							"patterns",
+							newSequence(newScalar("github/codeql-action*"))
+					)
+			);
+			getKeyAsMap(update, "groups").ifPresentOrElse(groups -> {
+				if (getKeyAsNode(groups, "github-codeql-action").isEmpty()) {
+					setKey(groups, "github-codeql-action", group);
+				}
+			}, () -> {
+				setKey(
+						update,
+						"groups",
+						newMap(newTuple("github-codeql-action", group))
+				);
+			});
+		});
+	}
+
 	public void addCooldownIfMissing() {
 		getUpdatesAsMappingNode().forEach(update -> {
 			getKeyAsMap(update, "cooldown").ifPresentOrElse(cooldown -> {

--- a/src/test/java/io/github/arlol/chorito/chores/DependabotChoreTest.java
+++ b/src/test/java/io/github/arlol/chorito/chores/DependabotChoreTest.java
@@ -50,6 +50,10 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				- package-ecosystem: "npm"
 				  directory: "/test-projects/vite-project/"
 				  schedule:
@@ -79,6 +83,10 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				- package-ecosystem: "npm"
 				  directory: "/"
 				  schedule:
@@ -110,6 +118,10 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				- package-ecosystem: "terraform"
 				  directory: "/"
 				  schedule:
@@ -135,6 +147,10 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				- package-ecosystem: "docker"
 				  directory: "/"
 				  schedule:
@@ -160,6 +176,10 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				- package-ecosystem: "docker"
 				  directory: "/"
 				  schedule:
@@ -185,6 +205,10 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				- package-ecosystem: "gomod"
 				  directory: "/"
 				  schedule:
@@ -211,6 +235,10 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				- package-ecosystem: "gomod"
 				  directory: "/services/api/"
 				  schedule:
@@ -247,6 +275,10 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				""");
 	}
 
@@ -288,18 +320,30 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				- package-ecosystem: "github-actions"
 				  directory: "/.github/actions/hello/"
 				  schedule:
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				- package-ecosystem: "github-actions"
 				  directory: "/.github/actions/bye/"
 				  schedule:
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				""");
 	}
 
@@ -337,6 +381,10 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				""");
 	}
 
@@ -386,6 +434,10 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				""");
 	}
 
@@ -423,6 +475,10 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				""");
 	}
 
@@ -451,6 +507,10 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				""");
 	}
 
@@ -470,6 +530,10 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				- package-ecosystem: "pip"
 				  directory: "/"
 				  schedule:
@@ -497,6 +561,10 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
 				- package-ecosystem: "devcontainers"
 				  directory: "/"
 				  schedule:

--- a/src/test/java/io/github/arlol/chorito/tools/DependabotConfigFileTest.java
+++ b/src/test/java/io/github/arlol/chorito/tools/DependabotConfigFileTest.java
@@ -98,6 +98,64 @@ public class DependabotConfigFileTest {
 	}
 
 	@Test
+	void testAddGitHubCodeQlActionGroupIfMissing() throws Exception {
+		var dependabotConfigFile = new DependabotConfigFile("""
+				updates:
+				- package-ecosystem: "github-actions"
+				- package-ecosystem: "maven"
+				""");
+		dependabotConfigFile.addGitHubCodeQlActionGroupIfMissing();
+		assertEquals("""
+				updates:
+				- package-ecosystem: "github-actions"
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
+				- package-ecosystem: "maven"
+				""", dependabotConfigFile.asString());
+	}
+
+	@Test
+	void testAddGitHubCodeQlActionGroupKeepsExistingGroups() throws Exception {
+		var dependabotConfigFile = new DependabotConfigFile("""
+				updates:
+				- package-ecosystem: "github-actions"
+				  groups:
+				    docker-actions:
+				      patterns:
+				      - "docker/*"
+				""");
+		dependabotConfigFile.addGitHubCodeQlActionGroupIfMissing();
+		assertEquals("""
+				updates:
+				- package-ecosystem: "github-actions"
+				  groups:
+				    docker-actions:
+				      patterns:
+				      - "docker/*"
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action*"
+				""", dependabotConfigFile.asString());
+	}
+
+	@Test
+	void testAddGitHubCodeQlActionGroupIsIdempotent() throws Exception {
+		var content = """
+				updates:
+				- package-ecosystem: "github-actions"
+				  groups:
+				    github-codeql-action:
+				      patterns:
+				      - "github/codeql-action-custom*"
+				""";
+		var dependabotConfigFile = new DependabotConfigFile(content);
+		dependabotConfigFile.addGitHubCodeQlActionGroupIfMissing();
+		assertEquals(content, dependabotConfigFile.asString());
+	}
+
+	@Test
 	void testAddCooldownIfTooLow() throws Exception {
 		var dependabotConfigFile = new DependabotConfigFile("""
 				updates:


### PR DESCRIPTION
## Summary
This PR adds automatic grouping of GitHub CodeQL Action updates in Dependabot configurations. The change ensures that `github/codeql-action*` updates are grouped together for `github-actions` package ecosystems, improving dependency management organization.

## Key Changes
- **New method `addGitHubCodeQlActionGroupIfMissing()`** in `DependabotConfigFile`: Automatically adds a `github-codeql-action` group with pattern `github/codeql-action*` to all `github-actions` package ecosystem entries
  - Preserves existing groups when adding the new group
  - Idempotent - does not duplicate if the group already exists
  - Only applies to `github-actions` package ecosystems
  
- **Integration in `DependabotChore`**: Calls the new method as part of the Dependabot configuration update workflow

- **Updated test expectations**: All test cases in `DependabotChoreTest` now expect the GitHub CodeQL Action group to be present in generated configurations

- **New unit tests** in `DependabotConfigFileTest`:
  - `testAddGitHubCodeQlActionGroupIfMissing()`: Verifies group is added when missing
  - `testAddGitHubCodeQlActionGroupKeepsExistingGroups()`: Ensures existing groups are preserved
  - `testAddGitHubCodeQlActionGroupIsIdempotent()`: Confirms the operation doesn't duplicate existing groups

- **Updated project configuration**: Applied the change to the project's own `.github/dependabot.yml`

## Implementation Details
The implementation uses the existing YAML manipulation utilities in `DependabotConfigFile` to safely add or update the groups configuration, maintaining consistency with how other Dependabot settings are managed.

https://claude.ai/code/session_01DzTMaS2dY5VRqToj5UBsM8