### PR TITLE
Add open-pull-requests-limit configuration to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,14 @@ updates:
     interval: "monthly"
   cooldown:
     default-days: 7
+  open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "monthly"
   cooldown:
     default-days: 7
+  open-pull-requests-limit: 10
   groups:
     github-codeql-action:
       patterns:
@@ -22,3 +24,4 @@ updates:
     interval: "monthly"
   cooldown:
     default-days: 7
+  open-pull-requests-limit: 10

--- a/src/main/java/io/github/arlol/chorito/chores/DependabotChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/DependabotChore.java
@@ -65,6 +65,7 @@ public class DependabotChore implements Chore {
 
 		dependabotConfigFile.changeDailyScheduleToMonthly();
 		dependabotConfigFile.addCooldownIfMissing();
+		dependabotConfigFile.addOpenPullRequestsLimitIfMissing();
 		dependabotConfigFile.addGitHubCodeQlActionGroupIfMissing();
 
 		FilesSilent.writeString(dependabotYml, dependabotConfigFile.asString());

--- a/src/main/java/io/github/arlol/chorito/tools/DependabotConfigFile.java
+++ b/src/main/java/io/github/arlol/chorito/tools/DependabotConfigFile.java
@@ -122,6 +122,27 @@ public class DependabotConfigFile {
 		});
 	}
 
+	public void addOpenPullRequestsLimitIfMissing() {
+		getUpdatesAsMappingNode().forEach(update -> {
+			getKeyAsScalar(update, "open-pull-requests-limit")
+					.ifPresentOrElse(limit -> {
+						if (Integer.parseInt(limit.getValue()) < 10) {
+							setKey(
+									update,
+									"open-pull-requests-limit",
+									newScalar(10)
+							);
+						}
+					}, () -> {
+						setKey(
+								update,
+								"open-pull-requests-limit",
+								newScalar(10)
+						);
+					});
+		});
+	}
+
 	public void addCooldownIfMissing() {
 		getUpdatesAsMappingNode().forEach(update -> {
 			getKeyAsMap(update, "cooldown").ifPresentOrElse(cooldown -> {

--- a/src/test/java/io/github/arlol/chorito/chores/DependabotChoreTest.java
+++ b/src/test/java/io/github/arlol/chorito/chores/DependabotChoreTest.java
@@ -50,6 +50,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				  groups:
 				    github-codeql-action:
 				      patterns:
@@ -60,6 +61,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				""");
 	}
 
@@ -83,6 +85,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				  groups:
 				    github-codeql-action:
 				      patterns:
@@ -93,12 +96,14 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				- package-ecosystem: "npm"
 				  directory: "/test-projects/vite-project/"
 				  schedule:
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				""");
 	}
 
@@ -118,6 +123,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				  groups:
 				    github-codeql-action:
 				      patterns:
@@ -128,6 +134,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				""");
 	}
 
@@ -147,6 +154,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				  groups:
 				    github-codeql-action:
 				      patterns:
@@ -157,6 +165,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				""");
 	}
 
@@ -176,6 +185,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				  groups:
 				    github-codeql-action:
 				      patterns:
@@ -186,6 +196,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				""");
 	}
 
@@ -205,6 +216,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				  groups:
 				    github-codeql-action:
 				      patterns:
@@ -215,6 +227,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				""");
 	}
 
@@ -235,6 +248,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				  groups:
 				    github-codeql-action:
 				      patterns:
@@ -245,6 +259,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				""");
 	}
 
@@ -255,7 +270,7 @@ public class DependabotChoreTest {
 				version: 2
 				updates:
 				  - package-ecosystem: "github-actions"
-				    open-pull-requests-limit: 1
+				    open-pull-requests-limit: 15
 				    directory: "/"
 				    schedule:
 				      interval: "monthly"
@@ -269,7 +284,7 @@ public class DependabotChoreTest {
 				version: 2
 				updates:
 				- package-ecosystem: "github-actions"
-				  open-pull-requests-limit: 1
+				  open-pull-requests-limit: 15
 				  directory: "/"
 				  schedule:
 				    interval: "monthly"
@@ -320,6 +335,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				  groups:
 				    github-codeql-action:
 				      patterns:
@@ -330,6 +346,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				  groups:
 				    github-codeql-action:
 				      patterns:
@@ -340,6 +357,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				  groups:
 				    github-codeql-action:
 				      patterns:
@@ -381,6 +399,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				  groups:
 				    github-codeql-action:
 				      patterns:
@@ -428,12 +447,14 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				- package-ecosystem: "github-actions"
 				  directory: "/"
 				  schedule:
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				  groups:
 				    github-codeql-action:
 				      patterns:
@@ -450,7 +471,7 @@ public class DependabotChoreTest {
 				version: 2
 				updates:
 				  - package-ecosystem: "maven"
-				    open-pull-requests-limit: 1
+				    open-pull-requests-limit: 15
 				    directory: "/subdir"
 				    schedule:
 				      interval: "monthly"
@@ -463,7 +484,7 @@ public class DependabotChoreTest {
 				version: 2
 				updates:
 				- package-ecosystem: "maven"
-				  open-pull-requests-limit: 1
+				  open-pull-requests-limit: 15
 				  directory: "/subdir"
 				  schedule:
 				    interval: "monthly"
@@ -475,6 +496,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				  groups:
 				    github-codeql-action:
 				      patterns:
@@ -501,7 +523,7 @@ public class DependabotChoreTest {
 				version: 2
 				updates:
 				- package-ecosystem: "github-actions"
-				  open-pull-requests-limit: 1
+				  open-pull-requests-limit: 10
 				  directory: "/"
 				  schedule:
 				    interval: "monthly"
@@ -530,6 +552,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				  groups:
 				    github-codeql-action:
 				      patterns:
@@ -540,6 +563,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				""");
 	}
 
@@ -561,6 +585,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				  groups:
 				    github-codeql-action:
 				      patterns:
@@ -571,6 +596,7 @@ public class DependabotChoreTest {
 				    interval: "monthly"
 				  cooldown:
 				    default-days: 7
+				  open-pull-requests-limit: 10
 				""");
 	}
 

--- a/src/test/java/io/github/arlol/chorito/tools/DependabotConfigFileTest.java
+++ b/src/test/java/io/github/arlol/chorito/tools/DependabotConfigFileTest.java
@@ -156,6 +156,47 @@ public class DependabotConfigFileTest {
 	}
 
 	@Test
+	void testAddOpenPullRequestsLimitIfMissing() throws Exception {
+		var dependabotConfigFile = new DependabotConfigFile("""
+				updates:
+				- package-ecosystem: "github-actions"
+				""");
+		dependabotConfigFile.addOpenPullRequestsLimitIfMissing();
+		assertEquals("""
+				updates:
+				- package-ecosystem: "github-actions"
+				  open-pull-requests-limit: 10
+				""", dependabotConfigFile.asString());
+	}
+
+	@Test
+	void testAddOpenPullRequestsLimitIfTooLow() throws Exception {
+		var dependabotConfigFile = new DependabotConfigFile("""
+				updates:
+				- package-ecosystem: "github-actions"
+				  open-pull-requests-limit: 1
+				""");
+		dependabotConfigFile.addOpenPullRequestsLimitIfMissing();
+		assertEquals("""
+				updates:
+				- package-ecosystem: "github-actions"
+				  open-pull-requests-limit: 10
+				""", dependabotConfigFile.asString());
+	}
+
+	@Test
+	void testAddOpenPullRequestsLimitKeepsHigherLimit() throws Exception {
+		var content = """
+				updates:
+				- package-ecosystem: "github-actions"
+				  open-pull-requests-limit: 15
+				""";
+		var dependabotConfigFile = new DependabotConfigFile(content);
+		dependabotConfigFile.addOpenPullRequestsLimitIfMissing();
+		assertEquals(content, dependabotConfigFile.asString());
+	}
+
+	@Test
 	void testAddCooldownIfTooLow() throws Exception {
 		var dependabotConfigFile = new DependabotConfigFile("""
 				updates:


### PR DESCRIPTION
## Summary
This PR adds automatic management of the `open-pull-requests-limit` setting in Dependabot configuration files. The limit is set to 10 for all package ecosystems, with logic to upgrade any existing limits that are lower than 10 while preserving higher values.

## Key Changes
- **New method `addOpenPullRequestsLimitIfMissing()`** in `DependabotConfigFile`: 
  - Adds `open-pull-requests-limit: 10` to any update entry that lacks this setting
  - Upgrades existing limits below 10 to 10
  - Preserves existing limits of 10 or higher
  
- **Integration in `DependabotChore`**: The new method is called during the chore execution pipeline, ensuring all Dependabot configurations are updated consistently

- **Comprehensive test coverage** with three test cases:
  - Adding the limit when missing
  - Upgrading low limits (below 10)
  - Preserving higher limits

- **Updated test expectations** across all `DependabotChoreTest` scenarios to reflect the new `open-pull-requests-limit: 10` setting in generated configurations

- **Applied to repository's own Dependabot config** (`.github/dependabot.yml`)

## Implementation Details
The implementation follows the existing pattern used for other Dependabot settings like cooldown and GitHub CodeQL action groups. It iterates through all update entries and uses conditional logic to either add the setting or update it based on the current value.

https://claude.ai/code/session_01EbbvorZwEdnuTXH7qdLbge