### PR TITLE
Enable Renovate to auto-update Maven plugin versions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -18,6 +18,20 @@
             "depNameTemplate": "com.github.spotbugs:spotbugs-maven-plugin",
             "datasourceTemplate": "maven",
         },
+        {
+            // Keeps the modernizer-maven-plugin version that
+            // ModernizerPluginChore writes into other repositories up to date.
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/^src/main/java/io/github/arlol/chorito/chores/ModernizerPluginChore\\.java$/",
+                "/^src/test/resources/io/github/arlol/chorito/modernizer-plugin/expected\\.xml$/",
+            ],
+            "matchStrings": [
+                "<groupId>org\\.gaul</groupId>\\s*<artifactId>modernizer-maven-plugin</artifactId>\\s*<version>(?<currentValue>.*?)</version>",
+            ],
+            "depNameTemplate": "org.gaul:modernizer-maven-plugin",
+            "datasourceTemplate": "maven",
+        },
     ],
     "extends": [
         "config:recommended",

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,22 @@
     "addLabels": [
         "{{manager}}",
     ],
+    "customManagers": [
+        {
+            // Keeps the spotbugs-maven-plugin version that SpotbugsPluginChore
+            // writes into other repositories up to date.
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/^src/main/java/io/github/arlol/chorito/chores/SpotbugsPluginChore\\.java$/",
+                "/^src/test/resources/io/github/arlol/chorito/spotbugs-plugin/expected\\.xml$/",
+            ],
+            "matchStrings": [
+                "<groupId>com\\.github\\.spotbugs</groupId>\\s*<artifactId>spotbugs-maven-plugin</artifactId>\\s*<version>(?<currentValue>.*?)</version>",
+            ],
+            "depNameTemplate": "com.github.spotbugs:spotbugs-maven-plugin",
+            "datasourceTemplate": "maven",
+        },
+    ],
     "extends": [
         "config:recommended",
     ],

--- a/src/main/java/io/github/arlol/chorito/chores/ModernizerPluginChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/ModernizerPluginChore.java
@@ -33,7 +33,7 @@ public class ModernizerPluginChore implements Chore {
 											<plugin>
 												<groupId>org.gaul</groupId>
 												<artifactId>modernizer-maven-plugin</artifactId>
-												<version>2.9.0</version>
+												<version>3.5.0</version>
 												<configuration>
 													<javaVersion>${java.version}</javaVersion>
 												</configuration>

--- a/src/main/java/io/github/arlol/chorito/chores/SpotbugsPluginChore.java
+++ b/src/main/java/io/github/arlol/chorito/chores/SpotbugsPluginChore.java
@@ -33,7 +33,7 @@ public class SpotbugsPluginChore implements Chore {
 											<plugin>
 												<groupId>com.github.spotbugs</groupId>
 												<artifactId>spotbugs-maven-plugin</artifactId>
-												<version>4.8.6.6</version>
+												<version>4.10.3.0</version>
 												<configuration>
 													<effort>Max</effort>
 													<threshold>Low</threshold>

--- a/src/test/resources/io/github/arlol/chorito/modernizer-plugin/expected.xml
+++ b/src/test/resources/io/github/arlol/chorito/modernizer-plugin/expected.xml
@@ -131,7 +131,7 @@
 			<plugin>
 				<groupId>org.gaul</groupId>
 				<artifactId>modernizer-maven-plugin</artifactId>
-				<version>2.9.0</version>
+				<version>3.5.0</version>
 				<configuration>
 					<javaVersion>${java.version}</javaVersion>
 				</configuration>

--- a/src/test/resources/io/github/arlol/chorito/spotbugs-plugin/expected.xml
+++ b/src/test/resources/io/github/arlol/chorito/spotbugs-plugin/expected.xml
@@ -115,7 +115,7 @@
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
-				<version>4.8.6.6</version>
+				<version>4.10.3.0</version>
 				<configuration>
 					<effort>Max</effort>
 					<threshold>Low</threshold>


### PR DESCRIPTION
## Summary
This PR adds Renovate custom managers to automatically detect and update Maven plugin versions that are embedded in the codebase. It also updates two Maven plugins to their latest versions.

## Key Changes
- **Renovate Configuration**: Added two custom regex managers to `renovate.json5`:
  - `spotbugs-maven-plugin` manager that tracks versions in `SpotbugsPluginChore.java` and its test resources
  - `modernizer-maven-plugin` manager that tracks versions in `ModernizerPluginChore.java` and its test resources
  
- **Dependency Updates**:
  - Updated `spotbugs-maven-plugin` from `4.8.6.6` to `4.10.3.0` in:
    - `SpotbugsPluginChore.java`
    - `src/test/resources/io/github/arlol/chorito/spotbugs-plugin/expected.xml`
  
  - Updated `modernizer-maven-plugin` from `2.9.0` to `3.5.0` in:
    - `ModernizerPluginChore.java`
    - `src/test/resources/io/github/arlol/chorito/modernizer-plugin/expected.xml`

## Implementation Details
The custom Renovate managers use regex patterns to extract Maven plugin versions from XML configuration blocks. This ensures that when these plugins are updated in the repository, Renovate will automatically create pull requests to keep the embedded versions synchronized across all files where they appear.

https://claude.ai/code/session_01BH8pDicCVMsXKToqngTRYY